### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/moadhbensassi/8ec4084d-db9f-4a01-a8cb-50662a18fcb5/4e725256-eaa9-4c88-8042-4597531e6515/_apis/work/boardbadge/61aac00b-31e0-476b-934e-4ab67533c1dd)](https://dev.azure.com/moadhbensassi/8ec4084d-db9f-4a01-a8cb-50662a18fcb5/_boards/board/t/4e725256-eaa9-4c88-8042-4597531e6515/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/moadhbensassi/8ec4084d-db9f-4a01-a8cb-50662a18fcb5/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.